### PR TITLE
Optional chaining on sheetClass core flag

### DIFF
--- a/scripts/levelup.js
+++ b/scripts/levelup.js
@@ -54,7 +54,7 @@ Hooks.on("renderActorSheet", (actor, html) => {
 })
 
 Hooks.on("renderItemSheet", (sheet, html) => {
-    switch (sheet.object.data.flags.core.sheetClass) {
+    switch (sheet.object.data.flags.core?.sheetClass) {
         case "dnd5e.Tidy5eSheet": {
 
         }


### PR DESCRIPTION
fixes #7

The core flags object doesn't always exist, such as the case for newly created actors where the default sheet is unset, as mentioned in the original issue. 

It might also be worth referencing the default sheet class `CONFIG.Actor.sheetClasses.character["dnd5e.Tidy5eSheet"]?.default` or something similar as well for any sheet-specific logic in the future. 